### PR TITLE
fix(docker): use UID 1001 to avoid host conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,9 @@ COPY wiki /usr/local/bin/
 RUN chmod +x /usr/local/bin/wiki
 
 # Create non-root user for security best practices
-RUN groupadd -g 1000 wiki && \
-    useradd -m -u 1000 -g wiki wiki
+# Using UID 1001 to avoid potential conflicts with host user IDs
+RUN groupadd -g 1001 wiki && \
+    useradd -m -u 1001 -g wiki wiki
 
 USER wiki
 WORKDIR /home/wiki


### PR DESCRIPTION
## Summary

Updates the Docker image to use UID 1001 instead of 1000 for the non-root user, avoiding potential conflicts with host user IDs.

## Changes

- Changed `groupadd -g 1000` to `groupadd -g 1001`
- Changed `useradd -m -u 1000 -g wiki` to `useradd -m -u 1001 -g wiki`

## Rationale

Using UID 1001 instead of 1000 reduces the risk of conflicts when running the container alongside user namespaces or when the host has a user with UID 1000 mapped to a different user.